### PR TITLE
openITCOCKPIT 4.8.5

### DIFF
--- a/src/openitcockpit-node.service
+++ b/src/openitcockpit-node.service
@@ -10,13 +10,15 @@ RestartSec=30
 Type=simple
 StandardOutput=null
 StandardError=null
-
+ExecStartPre=-/usr/bin/docker stop openitcockpit-node
+ExecStartPre=-/usr/bin/docker rm openitcockpit-node
 ExecStart=/usr/bin/docker run --rm \
 --init \
 -p 127.0.0.1:7084:8084 \
 -v /opt/openitc/frontend/:/opt/openitc/frontend/:ro \
 --name=openitcockpit-node \
 openitcockpit/puppeteer
+ExecStop=/usr/bin/docker stop openitcockpit-node
 [Install]
 WantedBy=docker.service
 


### PR DESCRIPTION
ITC-3404 Fix problem with service restart

Dieser Commit soll verhindern, das Systemd nicht erkennt das der Docker Container nicht mehr läuft, oder ein alter Container rumliegt und Systemd deshalb den Container nicht neu erstellen kann.

@dschmidt-itn hat das ganze hier schon einmal behoben: https://github.com/it-novum/puppeteer-docker/pull/5 Ich habe lediglich noch ein ExecStop ergänzt.